### PR TITLE
Improvements on padding and batching

### DIFF
--- a/src/wsi_patching/core/chunking_and_batching.py
+++ b/src/wsi_patching/core/chunking_and_batching.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, List, Literal, Optional, Tuple, Union
 
 from wsi_patching.regions_of_interest.roi_providers import WholeSlideProvider
 
@@ -29,7 +29,9 @@ class TilePlanner(Stage):
       - "center_in_roi": accept tile if its center is inside ROI (fallback for non-box in full_inside_bounds).
     """
 
-    def __init__(self, tile_selection_mode: str = "any_overlap"):
+    def __init__(
+        self, tile_selection_mode: Literal["any_overlap", "full_inside_bounds", "center_in_roi"] = "any_overlap"
+    ):
         self.tile_selection_mode = tile_selection_mode
 
     def validate(self) -> None:
@@ -50,9 +52,9 @@ class TilePlanner(Stage):
                 y1 = min(by + bh, H)
                 tiles: List[Tuple[int, int]] = []
                 y = by
-                while y + tile_size <= y1:
+                while y <= y1:
                     x = bx
-                    while x + tile_size <= x1:
+                    while x <= x1:
                         if self._accept_tile(roi, x, y, tile_size):
                             tiles.append((x, y))
                         x += stride
@@ -154,11 +156,10 @@ class ReadWindowChunker(Stage):
                         # Expand window to fully cover the included tiles (so slicing works)
                         max_tx = max(tx for tx, _ in in_window)
                         max_ty = max(ty for _, ty in in_window)
-                        need_wx1 = max_tx + tile_size
-                        need_wy1 = max_ty + tile_size
+                        # Ensure we cover the full tile in the window, except at slide edges
+                        new_wx1 = min(max_tx + tile_size, W)
+                        new_wy1 = min(max_ty + tile_size, H)
 
-                        new_wx1 = min(x_end, need_wx1)
-                        new_wy1 = min(y_end, need_wy1)
                         yield RegionTask(
                             plan.wsi_id, plan.wsi_path, (xx, yy, new_wx1 - xx, new_wy1 - yy), in_window, meta=plan.meta
                         )
@@ -177,7 +178,11 @@ class RegionReadAndBatch(Stage):
     """
 
     def __init__(
-        self, batch_size: int = 200, num_workers: int = 8, dtype: str = np.uint8, edge_policy: str = "pad_with_zeros"
+        self,
+        batch_size: int = 200,
+        num_workers: int = 8,
+        dtype: str = np.uint8,
+        edge_policy: Literal["drop", "pad_with_zeros", "pad_with_edge"] = "pad_with_zeros",
     ):
         self.batch_size = int(batch_size)
         self.num_workers = int(num_workers)

--- a/src/wsi_patching/core/chunking_and_batching.py
+++ b/src/wsi_patching/core/chunking_and_batching.py
@@ -9,7 +9,7 @@ import numpy as np
 from wsi_patching.backends.cucim_openslide import read_region
 from wsi_patching.backends.cupy_numpy import get_xp_backend
 from wsi_patching.core.pipeline import Stage
-from wsi_patching.regions_of_interest.rois import ROI, BoxROI
+from wsi_patching.regions_of_interest.rois import ROI
 from wsi_patching.utils.types import CollatedPatchBatch, RegionTask, Slide, SlideWithROIs, TilePlan
 
 
@@ -18,13 +18,18 @@ class TilePlanner(Stage):
     Divide slides (with or without ROIs) into patches on a regular grid.
 
     The TilePlanner emits a TilePlan. Each TilePlan corresponds to a single slide,
-    and might has a list of coords corresponding to coordinates of patches to be extracted.
+    and has a list of coords corresponding to coordinates of patches to be extracted.
     If ROIs are attached to the slide, all generated coordinates will lie within the ROIs.
     If no ROIs are attached, the WholeSlideProvider is used to generate a single ROI
     covering the entire slide.
+
+    tile_selection_mode:
+      - "any_overlap" (default): accept tile if any pixel overlaps ROI.
+      - "full_inside_bounds": accept tile only if fully inside ROI bounds rectangle (exact for BoxROI).
+      - "center_in_roi": accept tile if its center is inside ROI (fallback for non-box in full_inside_bounds).
     """
 
-    def __init__(self, tile_selection_mode: str = "full_inside_bounds"):
+    def __init__(self, tile_selection_mode: str = "any_overlap"):
         self.tile_selection_mode = tile_selection_mode
 
     def validate(self) -> None:
@@ -41,14 +46,12 @@ class TilePlanner(Stage):
             W, H = s.dims
             for idx, roi in enumerate(rois):
                 bx, by, bw, bh = roi.bounds()
-                x0 = _align_to_grid(max(0, bx), stride)
-                y0 = _align_to_grid(max(0, by), stride)
                 x1 = min(bx + bw, W)
                 y1 = min(by + bh, H)
                 tiles: List[Tuple[int, int]] = []
-                y = y0
+                y = by
                 while y + tile_size <= y1:
-                    x = x0
+                    x = bx
                     while x + tile_size <= x1:
                         if self._accept_tile(roi, x, y, tile_size):
                             tiles.append((x, y))
@@ -72,21 +75,17 @@ class TilePlanner(Stage):
 
     def _accept_tile(self, roi: ROI, tx: int, ty: int, tile_size: int) -> bool:
         mode = self.tile_selection_mode
-        if mode == "full_inside_bounds":
-            # Conservative: ensure full tile lies inside ROI bounds rectangle.
-            if isinstance(roi, BoxROI):
-                bx, by, bw, bh = roi.bounds()
-                return (tx >= bx) and (ty >= by) and (tx + tile_size <= bx + bw) and (ty + tile_size <= by + bh)
-            # For non-box geometries, fall back to center-in-ROI
-            mode = "center_in_roi"
 
-        if mode == "center_in_roi":
+        if mode == "any_overlap":
+            return roi.intersects_patch(tx, ty, tile_size, tile_size)
+        elif mode == "full_inside_bounds":
+            return roi.contains_patch(tx, ty, tile_size, tile_size)
+        elif mode == "center_in_roi":
             cx = tx + tile_size / 2.0
             cy = ty + tile_size / 2.0
             return roi.contains_point(cx, cy)
-
-        # Default fallback
-        return True
+        else:
+            raise ValueError(f"TilePlanner: unknown tile_selection_mode '{mode}'")
 
 
 class ReadWindowChunker(Stage):
@@ -132,7 +131,6 @@ class ReadWindowChunker(Stage):
 
     def __call__(self, it: Iterable[TilePlan]) -> Iterable[RegionTask]:
         tile_size = int(self.ctx["tile_size"])
-        stride = int(self.ctx["stride"])
 
         for plan in it:
             bx, by, bw, bh = plan.roi_bounds
@@ -141,21 +139,29 @@ class ReadWindowChunker(Stage):
                 self.log.warning(f"ReadWindowChunker: no tiles in plan for slide {plan.wsi_id} ROI {plan.roi_index}")
                 continue
 
-            x_start = _align_to_grid(max(0, bx), stride) if self.align_to_stride else bx
-            y_start = _align_to_grid(max(0, by), stride) if self.align_to_stride else by
             x_end, y_end = min(bx + bw, W), min(by + bh, H)
 
-            for yy in range(y_start, y_end, self.max_window_size):
-                for xx in range(x_start, x_end, self.max_window_size):
+            for yy in range(by, y_end, self.max_window_size):
+                for xx in range(bx, x_end, self.max_window_size):
                     ww, hh = min(self.max_window_size, x_end - xx), min(self.max_window_size, y_end - yy)
                     in_window: List[Tuple[int, int]] = []
                     wx1, wy1 = xx + ww, yy + hh
                     for tx, ty in plan.tiles:
-                        if tx >= xx and ty >= yy and (tx + tile_size) <= wx1 and (ty + tile_size) <= wy1:
+                        if (xx <= tx < wx1) and (yy <= ty < wy1):
                             in_window.append((tx, ty))
 
                     if in_window:
-                        yield RegionTask(plan.wsi_id, plan.wsi_path, (xx, yy, ww, hh), in_window, meta=plan.meta)
+                        # Expand window to fully cover the included tiles (so slicing works)
+                        max_tx = max(tx for tx, _ in in_window)
+                        max_ty = max(ty for _, ty in in_window)
+                        need_wx1 = max_tx + tile_size
+                        need_wy1 = max_ty + tile_size
+
+                        new_wx1 = min(x_end, need_wx1)
+                        new_wy1 = min(y_end, need_wy1)
+                        yield RegionTask(
+                            plan.wsi_id, plan.wsi_path, (xx, yy, new_wx1 - xx, new_wy1 - yy), in_window, meta=plan.meta
+                        )
 
 
 class RegionReadAndBatch(Stage):
@@ -170,15 +176,21 @@ class RegionReadAndBatch(Stage):
       - Changing dtype to e.g. np.float32 is allowed, but no normalization is applied
     """
 
-    def __init__(self, batch_size: int = 200, num_workers: int = 8, dtype: str = np.uint8):
+    def __init__(
+        self, batch_size: int = 200, num_workers: int = 8, dtype: str = np.uint8, edge_policy: str = "pad_with_zeros"
+    ):
         self.batch_size = int(batch_size)
         self.num_workers = int(num_workers)
         self.dtype = dtype
+        self.edge_policy = edge_policy
 
     def validate(self) -> None:
         self.ctx.require_key("tile_size")
         self.ctx.require_key("level")
         self.ctx.require_key("use_gpu")
+
+        if self.edge_policy not in {"drop", "pad_with_zeros", "pad_with_edge"}:
+            raise ValueError(f"RegionReadAndBatch: unknown edge_policy '{self.edge_policy}'")
 
     def __call__(self, it: Iterable[RegionTask]) -> Iterable[CollatedPatchBatch]:
         xp = get_xp_backend(self.ctx["use_gpu"])
@@ -198,7 +210,10 @@ class RegionReadAndBatch(Stage):
                 rx, ry = tx - x0, ty - y0
                 patch = region_img[ry : ry + tile_size, rx : rx + tile_size, :]
                 if patch.shape[:2] != (tile_size, tile_size):
-                    continue
+                    if self.edge_policy == "drop":
+                        continue
+                    self.log.info(f"RegionReadAndBatch: patch at edge, applying edge_policy {self.edge_policy}")
+                    patch = self._pad_to_tile_size(patch, tile_size, xp)
 
                 coords.append((tx, ty))
                 patches.append(patch)
@@ -218,10 +233,19 @@ class RegionReadAndBatch(Stage):
             cpb.add_col(k, np.array([v] * len(coords)))
         return cpb
 
+    def _pad_to_tile_size(self, patch, tile_size: int, xp_module):
+        """Right/bottom pad to (tile_size, tile_size). Works for numpy or cupy arrays."""
+        h, w = int(patch.shape[0]), int(patch.shape[1])
+        pad_h = max(0, tile_size - h)
+        pad_w = max(0, tile_size - w)
+        if pad_h == 0 and pad_w == 0:
+            return patch
 
-def _align_to_grid(v: int, stride: int, origin: int = 0) -> int:
-    """Return the smallest grid value <= v on grid defined by origin & stride."""
-    if stride <= 0:
-        raise ValueError("Stride must be positive")
-    r = (v - origin) % stride
-    return v if r == 0 else v - r
+        pad_spec = ((0, pad_h), (0, pad_w), (0, 0))
+
+        if self.edge_policy == "pad_with_zeros":
+            return xp_module.pad(patch, pad_spec, mode="constant", constant_values=0)
+        elif self.edge_policy == "pad_with_edge":
+            return xp_module.pad(patch, pad_spec, mode="edge")
+        else:
+            raise ValueError(f"Unknown edge_policy '{self.edge_policy}'")

--- a/src/wsi_patching/regions_of_interest/rois.py
+++ b/src/wsi_patching/regions_of_interest/rois.py
@@ -8,6 +8,22 @@ class ROI:
     def bounds(self) -> Box: ...
     def contains_point(self, x: float, y: float) -> bool: ...
 
+    def contains_patch(self, bx, by, bw, bh) -> bool:
+        return (
+            self.contains_point(bx, by)
+            and self.contains_point(bx + bw - 1, by)
+            and self.contains_point(bx, by + bh - 1)
+            and self.contains_point(bx + bw - 1, by + bh - 1)
+        )
+
+    def intersects_patch(self, bx, by, bw, bh) -> bool:
+        return (
+            self.contains_point(bx, by)
+            or self.contains_point(bx + bw - 1, by)
+            or self.contains_point(bx, by + bh - 1)
+            or self.contains_point(bx + bw - 1, by + bh - 1)
+        )
+
 
 @dataclass
 class BoxROI(ROI):

--- a/src/wsi_patching/utils/types.py
+++ b/src/wsi_patching/utils/types.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     import cupy as cp
 import numpy as np
 
+# Bounding box: (x, y, w, h)
 Box = Tuple[int, int, int, int]
 
 

--- a/tests/unit/src/wsi_patching/core/test_chunking_and_batching.py
+++ b/tests/unit/src/wsi_patching/core/test_chunking_and_batching.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from wsi_patching.core.chunking_and_batching import ReadWindowChunker, RegionReadAndBatch, TilePlanner, _align_to_grid
+from wsi_patching.core.chunking_and_batching import ReadWindowChunker, RegionReadAndBatch, TilePlanner
 from wsi_patching.regions_of_interest.rois import BoxROI
 from wsi_patching.utils.meta_typing import PipelineContext
 
@@ -44,25 +44,9 @@ class RegionTaskStub:
     meta: dict
 
 
-# ------------------- helpers -------------------
-class XPStub:
-    @staticmethod
-    def asarray(x, dtype=None):
-        return np.asarray(x, dtype=dtype)
-
-
 def fake_read_region(path, x, y, w, h, level, use_gpu, num_workers_cucim):
     # Return an HxWx3 array filled with unique value (for sanity checks if desired)
     return np.full((h, w, 3), fill_value=11, dtype=np.uint8)
-
-
-# ------------------- _align_to_grid -------------------
-def test_align_to_grid_basic_and_error():
-    assert _align_to_grid(17, 8, origin=0) == 16
-    assert _align_to_grid(7, 8, origin=0) == 0
-    assert _align_to_grid(33, 16, origin=5) == 21  # grid at 5,21,37,...
-    with pytest.raises(ValueError):
-        _ = _align_to_grid(10, 0)
 
 
 # ------------------- TilePlanner -------------------
@@ -84,9 +68,9 @@ def test_tileplanner_whole_slide_no_rois_generates_tiles():
 
 
 def test_tileplanner_center_mode_accepts_boundary_tiles():
-    # ROI that starts at (8,8) sized 8x8; tile_size 16
+    # ROI that starts at (8,8) sized 9x9; tile_size 16
     # full_inside_bounds would reject (0,0) tile, but center (8,8) lies inside -> accept in center_in_roi.
-    slide = SlideWithROIsStub("S", "/s", (40, 40), {}, rois=[BoxROI(8, 8, 8, 8)])
+    slide = SlideWithROIsStub("S", "/s", (40, 40), {}, rois=[BoxROI(8, 8, 9, 9)])
     tp = TilePlanner(tile_selection_mode="center_in_roi")
     tp.attach_context(PipelineContext({"tile_size": 16, "stride": 16, "level": 0}))
     tp.validate()
@@ -94,7 +78,7 @@ def test_tileplanner_center_mode_accepts_boundary_tiles():
     plans = list(tp(iter([slide])))
     assert len(plans) == 1
     plan = plans[0]
-    assert (0, 0) in plan.tiles  # accepted by center rule
+    assert (8, 8) in plan.tiles  # accepted by center rule
     # few tiles overall due to tiny ROI
     assert len(plan.tiles) >= 1
 
@@ -102,7 +86,7 @@ def test_tileplanner_center_mode_accepts_boundary_tiles():
 def test_tileplanner_warns_when_no_tiles(caplog):
     # Tiny slide 15x15 with tile_size 16 -> no tiles
     slide = SlideStub("S", "/s", (15, 15), {})
-    tp = TilePlanner()
+    tp = TilePlanner(tile_selection_mode="full_inside_bounds")
     tp.attach_context(PipelineContext({"tile_size": 16, "stride": 16, "level": 0}))
     tp.validate()
 
@@ -160,17 +144,17 @@ def test_readwindowchunker_groups_tiles_into_windows():
     r.validate()
 
     tasks = list(r(iter([plan])))
-    # Two windows: [0,0,32,32] with four tiles; [32,0,32,32] with one tile
+    # Two windows: [0,0,32,32] with four tiles; [32,0,32,16] with one tile
     assert len(tasks) == 2
     a, b = tasks
     assert a.region == (0, 0, 32, 32)
     assert sorted(a.tiles) == [(0, 0), (0, 16), (16, 0), (16, 16)]
-    assert b.region == (32, 0, 32, 32)
+    assert b.region == (32, 0, 32, 16)
     assert b.tiles == [(48, 0)]
 
 
 # ------------------- RegionReadAndBatch -------------------
-@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: XPStub)
+@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
 @patch("wsi_patching.core.chunking_and_batching.read_region", new=fake_read_region)
 def test_region_read_and_batch_happy_path_and_batch_split():
     # Build RegionTasks for a region 48x32 with four 16x16 tiles and one extra -> batches of 3 then 2
@@ -201,7 +185,7 @@ def test_region_read_and_batch_happy_path_and_batch_split():
     assert b1.patches.shape[1:] == (16, 16, 3)
 
 
-@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: XPStub)
+@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
 def test_region_read_and_batch_skips_incomplete_patches():
     # region 20x20, tile_size 16 -> tile at (8,8) gives rx=8, ry=8; patch 12x12 -> should be skipped
     def _fake_read_region(path, x, y, w, h, level, use_gpu, num_workers_cucim):
@@ -217,7 +201,7 @@ def test_region_read_and_batch_skips_incomplete_patches():
                 meta={},
             )
         ]
-        r = RegionReadAndBatch(batch_size=10, num_workers=1, dtype=np.uint8)
+        r = RegionReadAndBatch(batch_size=10, num_workers=1, dtype=np.uint8, edge_policy="drop")
         r.attach_context(PipelineContext({"tile_size": 16, "level": 0, "use_gpu": False}))
         r.validate()
 
@@ -226,5 +210,58 @@ def test_region_read_and_batch_skips_incomplete_patches():
         batch = out[0]
         # only the full (0,0) patch remains
         assert all(batch.coords[0] == 0)
-        print(batch.patches.shape)
         assert batch.patches.shape[0] == 1
+
+
+@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
+def test_region_read_and_batch_pads_incomplete_patches_with_zeros():
+    # region 20x20, tile_size 16 -> tile at (8,8) gives rx=8, ry=8; patch 12x12 -> should be padded to 16x16 with zeros
+    def _fake_read_region(path, x, y, w, h, level, use_gpu, num_workers_cucim):
+        return np.full((h, w, 3), 1, dtype=np.uint8)
+
+    with patch("wsi_patching.core.chunking_and_batching.read_region", new=_fake_read_region):
+        tasks = [
+            RegionTaskStub(
+                wsi_id="S",
+                wsi_path="/s",
+                region=(0, 0, 20, 20),
+                tiles=[(0, 0), (8, 8)],  # second will be partial (12x12)
+                meta={},
+            )
+        ]
+        r = RegionReadAndBatch(batch_size=10, num_workers=1, dtype=np.uint8, edge_policy="pad_with_zeros")
+        r.attach_context(PipelineContext({"tile_size": 16, "level": 0, "use_gpu": False}))
+        r.validate()
+
+        out = list(r(iter(tasks)))
+        assert len(out) == 1  # Still one collated batch
+        batch = out[0]  # Get the batch
+        assert all(batch.coords[1] == 8)
+        assert np.all(batch.patches[1, 12:, :, :] == 0)
+
+
+@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
+def test_region_read_and_batch_pads_incomplete_patches_with_edge():
+    # region 20x20, tile_size 16 -> tile at (8,8) gives rx=8, ry=8; patch 12x12 -> should be padded to 16x16 with zeros
+    def _fake_read_region(path, x, y, w, h, level, use_gpu, num_workers_cucim):
+        return np.full((h, w, 3), 1, dtype=np.uint8)
+
+    with patch("wsi_patching.core.chunking_and_batching.read_region", new=_fake_read_region):
+        tasks = [
+            RegionTaskStub(
+                wsi_id="S",
+                wsi_path="/s",
+                region=(0, 0, 20, 20),
+                tiles=[(0, 0), (8, 8)],  # second will be partial (12x12)
+                meta={},
+            )
+        ]
+        r = RegionReadAndBatch(batch_size=10, num_workers=1, dtype=np.uint8, edge_policy="pad_with_edge")
+        r.attach_context(PipelineContext({"tile_size": 16, "level": 0, "use_gpu": False}))
+        r.validate()
+
+        out = list(r(iter(tasks)))
+        assert len(out) == 1  # Still one collated batch
+        batch = out[0]  # Get the batch
+        assert all(batch.coords[1] == 8)
+        assert np.all(batch.patches[1, 12:, :, :] == 1)

--- a/tests/unit/src/wsi_patching/writers/test_numpy_mem_writer.py
+++ b/tests/unit/src/wsi_patching/writers/test_numpy_mem_writer.py
@@ -47,7 +47,6 @@ def test_write_single_batch_and_close(layout):
     # dtype conversion and ids replicated per patch
     assert imgs.dtype == np.float32
     assert out_coords.dtype == np.int64
-    print(ids)
     assert ids == ["S1"] * N
 
     # shape/layout checks


### PR DESCRIPTION
* Improved TilePlanners tile_selection_mode to default to method where all of the ROI is by default included
* Improved ReadWindowChunker to automatically grow window if tiles within the TilePlan go over the ROI border
* Improved RegionReadAndBatch. Added 'edge policy'. Any tiles that are at the edge of an ROI, but are not at the edge of the entire WSI, are included at all times with just their pixels. For patches at the edge of a wsi, the edge policy defines what happens to them.