### PR TITLE
Python support for python 3.8 up to and including 3.13

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: CPU unit tests
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ fromJson( ((github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/')) && '["3.8","3.9","3.10","3.11"]' || '["3.8","3.11"]' ) }}
+        python-version: ${{ fromJson( ((github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/')) && '["3.8","3.9","3.10","3.11", "3.12", "3.13"]' || '["3.8","3.13"]' ) }}
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A pragmatic pipeline for streaming whole-slide image (WSI) patches with region p
 
 ## 1) Library install
 
-Python ≥3.8 <3.12 is recommended. 3.12 is unsupported because cuCIM does not yet support it.
+Python ≥3.8 <3.14 is recommended. 3.14 is yet unsupported.
 ```
 # CPU install (not all functionality is supported for cpu only)
 pip install "wsi-patching @ git+https://github.com/amspath/wsi-patching-pipeline.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "wsi-patching"
 version = "0.1.0"
 description = "A High Performance Patching Library for Digital Pathology AI dataset creation."
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.14"
 authors = [{ name = "Robin van Hoorn", email = "r.d.vanhoorn@amsterdamumc.nl" }]
 dependencies = [
     "numpy",
@@ -22,7 +22,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-gpu = ["cucim-cu12", "cupy-cuda12x"]
+gpu = [
+    'cucim; python_version < "3.9" and platform_system != "Darwin"',
+    'cucim-cu12; python_version >= "3.9" and platform_system != "Darwin"',
+    'cupy-cuda12x; platform_system != "Darwin"',
+]
 dev = ["ruff", "pytest"]
 
 [tool.hatch.build.targets.wheel]

--- a/src/wsi_patching/transforms/macenko_normalizer.py
+++ b/src/wsi_patching/transforms/macenko_normalizer.py
@@ -128,7 +128,7 @@ class MacenkoNormalizer(Stage):
 
         # Least squares for C on fit pixels to get per-stain 99th percentile
         C, *_ = self._xp.linalg.lstsq(H_mat, OD.T, rcond=None)
-        max_sat = self._xp.percentile(C, 99.0, axis=1, keepdims=True).astype(self._xp.float32)
+        max_sat = self._xp.percentile(C, 99.0, axis=(1,), keepdims=True).astype(self._xp.float32)
         max_sat = self._xp.where(max_sat == 0, self._xp.asarray(1.0, dtype=self._xp.float32), max_sat)
 
         return H_mat, max_sat


### PR DESCRIPTION
* Added custom install in pyproject.toml for python 3.8, installing `cucim` instead of `cucim-cu12`.
* Changed macenko normalizer cupy call to use axis=(1,) instead of axis=1, as in python 3.8 the latter produced an error in cupy. 
* Updated readme with new version support.

Closes #36 