### PR TITLE
Fallback to openslide in case of unsupported file types in cucim

### DIFF
--- a/src/wsi_patching/backends/cucim_openslide.py
+++ b/src/wsi_patching/backends/cucim_openslide.py
@@ -1,7 +1,9 @@
-from typing import Optional, Tuple
+import logging
+from typing import Optional, Tuple, Union
 
 try:
     from cucim import CuImage
+    from cucim.clara._cucim import CuImage as CuImageType
 
     _cucim_available = True
 except ImportError:
@@ -10,25 +12,38 @@ except ImportError:
 import numpy as np
 from openslide import OpenSlide
 
+logger = logging.getLogger(__name__)
+_raised_warning = False
+
 
 def validate_slide_backend(use_gpu: bool) -> None:
     if use_gpu and not _cucim_available:
         raise ImportError("cuCIM is not available. Please install cuCIM to use GPU backend.")
 
 
-def _open_slide(path: str, use_gpu: bool):
+def _open_slide(path: str, use_gpu: bool) -> Union["CuImage", "OpenSlide"]:
     if _cucim_available and use_gpu:
-        return CuImage(str(path))
-    else:
-        return OpenSlide(str(path))
+        if path.lower().endswith((".tiff", ".tif", ".svs")):
+            return CuImage(str(path))
+        else:
+            global _raised_warning
+            if not _raised_warning:
+                logger.warning(
+                    f"cuCIM only supports tiff and svs, and does not support the file format '{path.split('.')[-1]}'. "
+                    "Falling back to OpenSlide."
+                )
+                _raised_warning = True
+    return OpenSlide(str(path))
 
 
 def get_dimensions_for_level(path: str, level: int, use_gpu: bool) -> Tuple[int, int]:
     slide = _open_slide(path, use_gpu)
-    if _cucim_available and use_gpu:
+    if _cucim_available and isinstance(slide, CuImageType):
         W, H = slide.resolutions["level_dimensions"][level]
     else:
         W, H = slide.level_dimensions[level]
+
+    slide.close()
     return int(W), int(H)
 
 
@@ -39,11 +54,12 @@ def read_region(
     Return requested region at the given level.
     """
     img = _open_slide(path, use_gpu)
-    if use_gpu:
+    if _cucim_available and isinstance(img, CuImageType):
         # Use cuCIM
         region = img.read_region(location=(x, y), size=(w, h), level=level, num_workers=num_workers_cucim)
     else:
         # Use OpenSlide
         region = img.read_region((x, y), level, (w, h)).convert("RGB")
 
+    img.close()
     return np.asarray(region)

--- a/tests/unit/src/wsi_patching/backends/test_cucim_openslide.py
+++ b/tests/unit/src/wsi_patching/backends/test_cucim_openslide.py
@@ -18,6 +18,9 @@ class FakeCuImage:
         w, h = size
         return np.full((h, w, 3), 7, dtype=np.uint8)
 
+    def close(self):
+        pass
+
 
 class FakePILImage:
     """Minimal object with .convert('RGB') returning an array-compatible object."""
@@ -42,6 +45,9 @@ class FakeOpenSlide:
         w, h = size
         return FakePILImage(w, h, fill=5)
 
+    def close(self):
+        pass
+
 
 # ---------- tests ----------
 def test_validate_slide_backend_raises_when_gpu_requested_but_cucim_missing(monkeypatch):
@@ -63,11 +69,15 @@ def test_get_dimensions_for_level_cpu(monkeypatch):
 
 
 def test_get_dimensions_for_level_gpu_with_cucim(monkeypatch):
+    # Pretend cuCIM is available
     monkeypatch.setattr(mod, "_cucim_available", True, raising=True)
+
+    # CuImage is the constructor, CuImageType is the type used in isinstance(...)
     monkeypatch.setattr(mod, "CuImage", FakeCuImage, raising=False)
+    monkeypatch.setattr(mod, "CuImageType", FakeCuImage, raising=False)
 
     W, H = mod.get_dimensions_for_level("dummy.tif", level=1, use_gpu=True)
-    assert (W, H) == (25, 10)
+    assert (W, H) == (25, 10)  # from FakeCuImage.resolutions["level_dimensions"][1]
     assert isinstance(W, int) and isinstance(H, int)
 
 
@@ -83,6 +93,7 @@ def test_read_region_cpu_returns_numpy_and_uses_openslide(monkeypatch):
 
 
 def test_read_region_gpu_returns_numpy_and_passes_num_workers(monkeypatch):
+    # Pretend cuCIM is available
     monkeypatch.setattr(mod, "_cucim_available", True, raising=True)
 
     fake = FakeCuImage("gpu.tif")
@@ -93,6 +104,8 @@ def test_read_region_gpu_returns_numpy_and_passes_num_workers(monkeypatch):
         return fake
 
     monkeypatch.setattr(mod, "CuImage", _ctor, raising=False)
+    # CuImageType is the type for isinstance(...); fake is an instance of FakeCuImage
+    monkeypatch.setattr(mod, "CuImageType", FakeCuImage, raising=False)
 
     arr = mod.read_region(path="gpu.tif", x=1, y=2, w=4, h=6, level=1, use_gpu=True, num_workers_cucim=13)
     assert isinstance(arr, np.ndarray)


### PR DESCRIPTION
Cucim only really supports svs and tiff. So if you enter a different type of wsi, it should automatically fall back to openslide for loading the wsi.

Closes #40 