### PR TITLE
Fixed patching such that when stride<tile_size, it stops patching if …

### DIFF
--- a/src/wsi_patching/core/chunking_and_batching.py
+++ b/src/wsi_patching/core/chunking_and_batching.py
@@ -42,6 +42,17 @@ class TilePlanner(Stage):
         ctx["tile_size"] = self.tile_size
         ctx["stride"] = self.stride
 
+    def validate(self) -> None:
+        self.ctx.require_key("tile_size")
+        self.ctx.require_key("stride")
+
+        if self.ctx["tile_size"] <= 0:
+            raise ValueError("Tile size must be positive")
+        if self.ctx["stride"] <= 0:
+            raise ValueError("Stride must be positive")
+        if self.ctx["stride"] > self.ctx["tile_size"]:
+            self.log.warning("Stride is larger than tile size, resulting in gaps between tiles.")
+
     def __call__(self, it: Iterable[Union[Slide, SlideWithROIs]]) -> Iterable[TilePlan]:
         tile_size = int(self.ctx["tile_size"])
         stride = int(self.ctx["stride"])
@@ -54,14 +65,14 @@ class TilePlanner(Stage):
                 x1 = min(bx + bw, W)
                 y1 = min(by + bh, H)
                 tiles: List[Tuple[int, int]] = []
-                y = by
-                while y <= y1:
-                    x = bx
-                    while x <= x1:
+
+                xs = self._axis_positions(bx, x1, tile_size, stride)
+                ys = self._axis_positions(by, y1, tile_size, stride)
+
+                for y in ys:
+                    for x in xs:
                         if self._accept_tile(roi, x, y, tile_size):
                             tiles.append((x, y))
-                        x += stride
-                    y += stride
 
                 if tiles:
                     yield TilePlan(
@@ -80,6 +91,30 @@ class TilePlanner(Stage):
                     )
                 else:
                     self.log.warning(f"No tiles found for slide {s.wsi_id} ROI {idx} bounds {bx, by, bw, bh}")
+
+    def _axis_positions(self, start: int, end: int, tile_size: int, stride: int) -> List[int]:
+        """
+        Generate tile start positions along a single axis.
+
+        Assumes stride < tile_size if you want overlap & full coverage.
+        """
+        roi_len = end - start
+
+        # 1) ROI smaller than a tile: just one tile anchored at start.
+        if roi_len <= tile_size:
+            return [start]
+
+        # 2) Normal case: stride < tile_size, ROI larger than tile.
+        positions: List[int] = []
+        pos = start
+
+        # keep stepping as long as "previous start + tile_size" still needs to reach 'end'
+        last_tile_correction = -stride + tile_size if stride < tile_size else 0
+        while pos + last_tile_correction < end:
+            positions.append(pos)
+            pos += stride
+
+        return positions
 
     def _accept_tile(self, roi: ROI, tx: int, ty: int, tile_size: int) -> bool:
         mode = self.tile_selection_mode

--- a/tests/unit/src/wsi_patching/core/test_chunking_and_batching.py
+++ b/tests/unit/src/wsi_patching/core/test_chunking_and_batching.py
@@ -62,6 +62,66 @@ def test_tileplanner_warns_when_no_tiles(caplog):
     assert "No tiles found for slide S ROI 0" in caplog.text
 
 
+def test_tileplanner_roi_smaller_than_tile_size_single_tile():
+    """
+    ROI is smaller than the tile size: we should only get a single tile
+    anchored at the ROI start, even if stride < tile_size.
+    """
+    # ROI 1000x1000, tile_size 1024, stride 700
+    slide = SlideWithROIs("S", "/s", (1000, 1000), {}, rois=[BoxROI(0, 0, 1000, 1000)])
+    tp = TilePlanner(tile_size=1024, stride=700, tile_selection_mode="any_overlap")
+
+    tp.attach_context(PipelineContext({"tile_size": 1024, "stride": 700, "level": 0}))
+    tp.validate()
+
+    plans = list(tp(iter([slide])))
+    assert len(plans) == 1
+    plan = plans[0]
+
+    # Only a single tile is needed to cover the ROI
+    assert len(plan.tiles) == 1
+    assert plan.tiles[0] == (0, 0)
+
+
+def test_tileplanner_large_roi_with_overlap_no_redundant_tiles():
+    """
+    ROI larger than tile, stride < tile_size:
+    We want overlapping tiles that cover the ROI, but *not* an extra
+    last row/column of redundant tiles (the 9 vs 4 bug).
+    """
+    # ROI 2000x2000, tile_size 1200, stride 900
+    # Old behavior: 3x3 grid = 9 tiles.
+    # New behavior (axis_positions): starts at [0, 900] -> 2x2 grid = 4 tiles.
+    slide = SlideWithROIs("S", "/s", (2000, 2000), {}, rois=[BoxROI(0, 0, 2000, 2000)])
+    tp = TilePlanner(tile_size=1200, stride=900, tile_selection_mode="any_overlap")
+
+    tp.attach_context(PipelineContext({"tile_size": 1200, "stride": 900, "level": 0}))
+    tp.validate()
+
+    plans = list(tp(iter([slide])))
+    assert len(plans) == 1
+    plan = plans[0]
+
+    # Expect exactly 4 tiles at the useful start positions
+    expected_tiles = {(0, 0), (900, 0), (0, 900), (900, 900)}
+    assert set(plan.tiles) == expected_tiles
+    assert len(plan.tiles) == 4
+
+
+def test_tileplanner_validate_warns_when_stride_larger_than_tile_size(caplog):
+    """
+    When stride > tile_size, validate() should emit a warning about gaps
+    between tiles (behavior is allowed, but not guaranteed to cover ROI).
+    """
+    tp = TilePlanner(tile_size=16, stride=32, tile_selection_mode="any_overlap")
+    tp.attach_context(PipelineContext({"tile_size": 16, "stride": 32, "level": 0}))
+
+    caplog.set_level("WARNING")
+    tp.validate()
+
+    assert "Stride is larger than tile size" in caplog.text
+
+
 # ------------------- ReadWindowChunker -------------------
 def test_readwindowchunker_validate_defaults_and_guards(caplog):
     r = ReadWindowChunker(max_window_size=None)


### PR DESCRIPTION
…whole ROI is included

When stride<tile_size it would generate too many patches, continuing with patching even though the whole ROI was already covered. This can add quite a bit of patches (An ROI of 2000x2000px, a tile_size of 1200 and a stride of 900 should give 4 patches, but gave 9). 

Closes #39 