### PR TITLE
Change WSI grid to allow for 'level' 'mpp' and 'downsample'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install -e .[gpu]
 `demo.py` shows you how to build a basic pipeline for creating a WebDataset (A materializing pipeline)
 ```python
 p = (
-    WSIGrid(slides=slides, level=0, use_gpu=True)
+    WSIGrid(slides=slides, resolution=0, unit="level", use_gpu=True)
     .then(AttachROIs(providers=[RectROIProvider(rois_dict)]))
     .then(PatchExtractor(tile_size=224, stride=224, max_batch_size=800))
     .then(CellVitTissueClassifierFilter())
@@ -52,7 +52,7 @@ p.materialize(cpu_processes=4)
 `numpy_mem_writer_demo.py` shows you how to build a basic pipeline for patching up a wsi in memory, without the need of writing to disk (RAM heavy for larger datasets, obviously).
 ```python
 p = (
-    WSIGrid(slides=slides, level=0, use_gpu=True)
+    WSIGrid(slides=slides, resolution=0, unit="level", use_gpu=True)
     .then(PatchExtractor(tile_size=256, stride=256, max_batch_size=800, num_workers=4))
     .then(LowContrastBackgroundFilter(range_threshold=0.2))
     .then(MacenkoNormalizer())

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -40,7 +40,7 @@ def main(argv=None):
     rois_dict = {Path(s).stem: [(0, 0, 4000, 4000)] for s in slides}
 
     p = (
-        WSIGrid(slides=slides, level=0, use_gpu=True)
+        WSIGrid(slides=slides, resolution=0, unit="level", use_gpu=True)
         .then(AttachROIs(providers=[RectROIProvider(rois_dict)]))
         .then(PatchExtractor(tile_size=224, stride=224, max_batch_size=args.batch, num_workers=args.num_workers))
         .then(PNGEncoder())

--- a/examples/numpy_stream_writer_demo.py
+++ b/examples/numpy_stream_writer_demo.py
@@ -13,7 +13,7 @@ def main():
     slides = ["./data/RBIO-GC072-HE-01.tiff"]
 
     p = (
-        WSIGrid(slides=slides, level=0, use_gpu=True)
+        WSIGrid(slides=slides, resolution=0, unit="level", use_gpu=True)
         .then(PatchExtractor(tile_size=256, stride=256, max_batch_size=800, num_workers=4))
         .then(LowContrastBackgroundFilter(range_threshold=0.2))
         .then(PenArtifactFilter())

--- a/examples/torch_stream_writer_demo.py
+++ b/examples/torch_stream_writer_demo.py
@@ -12,7 +12,7 @@ def main():
     roi_xml = {"RT14-09099_HE": "./data/RT14-09099_HE.xml"}
 
     p = (
-        WSIGrid(slides=slides, level=0, use_gpu=True)
+        WSIGrid(slides=slides, resolution=0, unit="level", use_gpu=True)
         .then(AttachROIs(providers=[RectROIfromXMLProvider(rois=roi_xml)]))
         .then(PatchExtractor(tile_size=256, stride=256, max_batch_size=800, num_workers=4))
         .then(PenArtifactFilter())

--- a/src/wsi_patching/backends/cucim_openslide.py
+++ b/src/wsi_patching/backends/cucim_openslide.py
@@ -1,5 +1,8 @@
 import logging
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
+
+import numpy as np
+from openslide import OpenSlide
 
 try:
     from cucim import CuImage
@@ -9,8 +12,6 @@ try:
 except ImportError:
     _cucim_available = False
 
-import numpy as np
-from openslide import OpenSlide
 
 logger = logging.getLogger(__name__)
 _raised_warning = False
@@ -33,18 +34,12 @@ def _open_slide(path: str, use_gpu: bool) -> Union["CuImage", "OpenSlide"]:
                     "Falling back to OpenSlide."
                 )
                 _raised_warning = True
+
     return OpenSlide(str(path))
 
 
-def get_dimensions_for_level(path: str, level: int, use_gpu: bool) -> Tuple[int, int]:
-    slide = _open_slide(path, use_gpu)
-    if _cucim_available and isinstance(slide, CuImageType):
-        W, H = slide.resolutions["level_dimensions"][level]
-    else:
-        W, H = slide.level_dimensions[level]
-
-    slide.close()
-    return int(W), int(H)
+def _open_slide_using_openslide(path: str) -> "OpenSlide":
+    return OpenSlide(str(path))
 
 
 def read_region(
@@ -54,7 +49,7 @@ def read_region(
     Return requested region at the given level.
     """
     img = _open_slide(path, use_gpu)
-    if _cucim_available and isinstance(img, CuImageType):
+    if isinstance(img, CuImageType):
         # Use cuCIM
         region = img.read_region(location=(x, y), size=(w, h), level=level, num_workers=num_workers_cucim)
     else:
@@ -63,3 +58,120 @@ def read_region(
 
     img.close()
     return np.asarray(region)
+
+
+def get_dimensions_for_level(path: str, level: int) -> Tuple[int, int]:
+    """
+    Returns:
+        W: int
+        H: int
+    """
+    slide = _open_slide_using_openslide(path)
+    try:
+        assert 0 <= level < slide.level_count, f"Level {level} exceeds maximum level {slide.level_count - 1}."
+        W, H = slide.level_dimensions[level]
+        return int(W), int(H)
+    finally:
+        slide.close()
+
+
+def get_level_for_resolution(
+    path: str,
+    resolution: float,
+    unit: Literal["level", "mpp", "downsample"],
+    fallback_mode: Literal["nearest", "floor", "ceil", "error"],
+) -> int:
+    """
+    Determine which pyramid level to use for a given resolution specification.
+
+    Args:
+        path: Path to the WSI.
+        resolution: Requested resolution value.
+            - If unit == "level": pyramid level index (0, 1, 2, ...)
+            - If unit == "mpp": microns per pixel.
+            - If unit == "downsample": Downsample factor relative to level 0.
+        unit: Resolution unit ("level", "mpp", or "downsample").
+        fallback_mode:
+            - "nearest": pick level whose value is closest to 'resolution'.
+            - "floor":   pick coarsest level with value >= 'resolution'
+                         (if none, use coarsest level).
+            - "ceil":    pick finest level with value <= 'resolution'
+                         (if none, use finest level, i.e. level 0).
+            - "error":   require (almost) exact match, otherwise raise ValueError.
+
+    Returns:
+        level_idx: int
+    """
+    slide = _open_slide_using_openslide(path)
+
+    try:
+        # --- Trivial case: unit == "level" ---------------------------------
+        if unit == "level":
+            if not float(resolution).is_integer():
+                raise ValueError("When unit is 'level', resolution must be an integer.")
+            level_idx = int(resolution)
+            if level_idx < 0:
+                raise ValueError("Level must be non-negative.")
+            if level_idx >= slide.level_count:
+                raise ValueError(f"Requested level {level_idx} exceeds maximum level {slide.level_count - 1}.")
+            return level_idx
+
+        # --- Compute per-level values for mpp / downsample --------------------
+        level_downsamples = list(slide.level_downsamples)  # e.g. [1.0, 2.0, 4.0, ...]
+        requested = float(resolution)
+
+        if unit == "mpp":
+            mpp0 = slide.properties.get("openslide.mpp-x")
+            if mpp0 is None:
+                raise ValueError("Slide does not expose 'openslide.mpp-x' mpp metadata.")
+            mpp0 = float(mpp0)
+            # Effective mpp per level
+            values = [mpp0 * float(ds) for ds in level_downsamples]
+
+        elif unit == "downsample":
+            # Downsample factor vs level 0
+            values = [float(ds) for ds in level_downsamples]
+
+        else:
+            raise ValueError(f"Unknown unit: {unit}")
+
+        # --- Helper: nearest index -----------------------------------------
+        def nearest_idx() -> int:
+            return min(range(len(values)), key=lambda i: abs(values[i] - requested))
+
+        # --- Select level according to fallback_mode ------------------------
+        if fallback_mode == "nearest":
+            level_idx = nearest_idx()
+
+        elif fallback_mode == "floor":
+            # coarsest level with value >= requested (larger value = coarser)
+            eligible = [i for i, v in enumerate(values) if v >= requested]
+            if eligible:
+                level_idx = min(eligible, key=lambda i: values[i])
+            else:
+                # if none >= requested, use coarsest (last) level
+                level_idx = len(values) - 1
+
+        elif fallback_mode == "ceil":
+            # finest level with value <= requested
+            eligible = [i for i, v in enumerate(values) if v <= requested]
+            if eligible:
+                level_idx = max(eligible, key=lambda i: values[i])
+            else:
+                # if none <= requested, use finest (level 0)
+                level_idx = 0
+
+        elif fallback_mode == "error":
+            tol = 1e-6
+            matches = [i for i, v in enumerate(values) if abs(v - requested) <= tol * max(1.0, abs(requested))]
+            if not matches:
+                raise ValueError(f"No exact {unit} match for requested {requested}; available values: {values}")
+            level_idx = matches[0]
+
+        else:
+            raise ValueError(f"Unknown fallback_mode: {fallback_mode}")
+
+        return level_idx
+
+    finally:
+        slide.close()

--- a/src/wsi_patching/backends/cucim_openslide.py
+++ b/src/wsi_patching/backends/cucim_openslide.py
@@ -49,7 +49,7 @@ def read_region(
     Return requested region at the given level.
     """
     img = _open_slide(path, use_gpu)
-    if isinstance(img, CuImageType):
+    if _cucim_available and isinstance(img, CuImageType):
         # Use cuCIM
         region = img.read_region(location=(x, y), size=(w, h), level=level, num_workers=num_workers_cucim)
     else:

--- a/src/wsi_patching/core/chunking_and_batching.py
+++ b/src/wsi_patching/core/chunking_and_batching.py
@@ -79,6 +79,7 @@ class TilePlanner(Stage):
                         wsi_id=s.wsi_id,
                         wsi_path=s.wsi_path,
                         dims=s.dims,
+                        level=s.level,
                         roi_index=idx,
                         roi_bounds=(bx, by, bw, bh),
                         tiles=tiles,
@@ -194,6 +195,7 @@ class ReadWindowChunker(Stage):
                             wsi_id=plan.wsi_id,
                             wsi_path=plan.wsi_path,
                             wsi_dims=plan.dims,
+                            level=plan.level,
                             region=(x_region_start, y_region_start, region_width, region_height),
                             tiles=in_window,
                             meta=plan.meta,
@@ -244,7 +246,6 @@ class RegionReadAndBatch(Stage):
 
     def validate(self) -> None:
         self.ctx.require_key("tile_size")
-        self.ctx.require_key("level")
         self.ctx.require_key("use_gpu")
 
         if self.wsi_edge_policy not in {"drop", "pad_with_zeros", "pad_with_edge"}:
@@ -253,7 +254,6 @@ class RegionReadAndBatch(Stage):
     def __call__(self, it: Iterable[RegionTask]) -> Iterable[CollatedPatchBatch]:
         xp = get_xp_backend(self.ctx["use_gpu"])
         tile_size = int(self.ctx["tile_size"])
-        level = int(self.ctx["level"])
 
         for task in it:
             x0, y0, w, h = task.region
@@ -267,7 +267,7 @@ class RegionReadAndBatch(Stage):
                     h = min(h, task.wsi_dims[1])
 
             region_img = read_region(
-                task.wsi_path, x0, y0, w, h, level, use_gpu=self.ctx["use_gpu"], num_workers_cucim=self.num_workers
+                task.wsi_path, x0, y0, w, h, task.level, use_gpu=self.ctx["use_gpu"], num_workers_cucim=self.num_workers
             )
 
             coords: List[Tuple[int, int]] = []

--- a/src/wsi_patching/core/chunking_and_batching.py
+++ b/src/wsi_patching/core/chunking_and_batching.py
@@ -34,6 +34,15 @@ class TilePlanner(Stage):
         stride: int,
         tile_selection_mode: Literal["any_overlap", "full_inside_bounds", "center_in_roi"] = "any_overlap",
     ):
+        """
+        Args:
+            tile_size: size of square patches to extract
+            stride: spacing between patch top-left corners of each of the patches
+            tile_selection_mode: how to select tiles with respect to ROIs.
+                - "any_overlap": accept tile if any pixel overlaps ROI.
+                - "full_inside_bounds": accept tile only if fully inside ROI bounds rectangle (exact for BoxROI).
+                - "center_in_roi": accept tile if its center is inside ROI.
+        """
         self.tile_size = tile_size
         self.stride = stride
         self.tile_selection_mode = tile_selection_mode
@@ -224,7 +233,7 @@ class RegionReadAndBatch(Stage):
         dtype: str = np.uint8,
     ):
         """
-        Parameters:
+        Args:
             batch_size: Maximum number of patches per output batch
             num_workers: number of parallel workers for reading WSI images using cuCIM
             wsi_edge_policy: how to handle tiles that extend beyond the WSI edge.
@@ -340,7 +349,7 @@ class PatchExtractor(Stage):
         max_window_size: Optional[int] = None,
     ):
         """
-        Parameters:
+        Args:
             tile_size: size of square patches to extract
             stride: spacing between patch top-left corners of each of the patches
             tile_selection_mode: how to select tiles with respect to ROIs.

--- a/src/wsi_patching/core/types/types.py
+++ b/src/wsi_patching/core/types/types.py
@@ -17,6 +17,7 @@ class SlideBase:
     wsi_id: str
     wsi_path: str
     dims: Tuple[int, int]
+    level: int
     meta: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -35,6 +36,7 @@ class TilePlan:
     wsi_id: str
     wsi_path: str
     dims: Tuple[int, int]
+    level: int
     roi_index: int
     roi_bounds: Box
     tiles: List[Tuple[int, int]]
@@ -46,6 +48,7 @@ class RegionTask:
     wsi_id: str
     wsi_path: str
     wsi_dims: Tuple[int, int]
+    level: int
     region: Box
     tiles: List[Tuple[int, int]]
     meta: Dict[str, Any] = field(default_factory=dict)

--- a/src/wsi_patching/core/wsi_grid.py
+++ b/src/wsi_patching/core/wsi_grid.py
@@ -26,6 +26,17 @@ class WSIGrid(Stage):
         unit: Literal["level", "mpp", "downsample"],
         fallback_mode: Literal["nearest", "floor", "ceil", "error"] = "error",
     ):
+        """
+        Initializes the WSIGrid stage, the starting point of a WSI patching pipeline.
+
+        Args:
+            slides: List of file paths to whole slide images (WSIs).
+            use_gpu: Whether to use GPU-accelerated backends when possible (e.g., cuCIM, CuPy).
+            resolution: Desired resolution for patch extraction.
+            unit: Unit of the resolution ("level", "mpp", or "downsample").
+            fallback_mode: Strategy for selecting resolution if exact match is unavailable (default is "error").
+                Options are ("nearest", "floor", "ceil", "error").
+        """
         self.slides = list(slides)
         self.use_gpu = use_gpu
         self.resolution = resolution

--- a/src/wsi_patching/core/wsi_grid.py
+++ b/src/wsi_patching/core/wsi_grid.py
@@ -1,7 +1,11 @@
 from pathlib import Path
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, Literal
 
-from wsi_patching.backends.cucim_openslide import get_dimensions_for_level, validate_slide_backend
+from wsi_patching.backends.cucim_openslide import (
+    get_dimensions_for_level,
+    get_level_for_resolution,
+    validate_slide_backend,
+)
 from wsi_patching.backends.cupy_numpy import validate_xp_backend
 from wsi_patching.backends.torch_device import get_torch_device
 from wsi_patching.core.pipeline import PipelineContext, Stage
@@ -14,14 +18,25 @@ class WSIGrid(Stage):
     (MVP simplified: we do not enumerate *all tiles* here; Regionize will do per-ROI tiling.)
     """
 
-    def __init__(self, slides: List[str], use_gpu: bool, level: int = 0):
+    def __init__(
+        self,
+        slides: List[str],
+        use_gpu: bool,
+        resolution: float,
+        unit: Literal["level", "mpp", "downsample"],
+        fallback_mode: Literal["nearest", "floor", "ceil", "error"] = "error",
+    ):
         self.slides = list(slides)
         self.use_gpu = use_gpu
-        self.level = level
+        self.resolution = resolution
+        self.unit = unit
+        self.fallback_mode = fallback_mode
 
     def export_context(self, ctx: "PipelineContext") -> None:
         # Seed/override global grid parameters for other stages to read.
-        ctx["level"] = self.level
+        ctx["resolution"] = self.resolution
+        ctx["unit"] = self.unit
+        ctx["fallback_mode"] = self.fallback_mode
         ctx["use_gpu"] = self.use_gpu
 
     def validate(self) -> None:
@@ -30,7 +45,13 @@ class WSIGrid(Stage):
         get_torch_device(self.use_gpu)
 
     def for_slide(self, slide_path: str) -> "Stage":
-        return WSIGrid(slides=[slide_path], use_gpu=self.use_gpu, level=self.level)
+        return WSIGrid(
+            slides=[slide_path],
+            use_gpu=self.use_gpu,
+            resolution=self.resolution,
+            unit=self.unit,
+            fallback_mode=self.fallback_mode,
+        )
 
     def __call__(self, it: Iterable[Any]) -> Iterable[Slide]:
         for path in self.slides:
@@ -39,13 +60,23 @@ class WSIGrid(Stage):
                 raise FileNotFoundError(f"Slide path does not exist: {path}")
 
             wsi_id = Path(path).stem
-            W, H = get_dimensions_for_level(path, self.level, self.use_gpu)
+            selected_level = get_level_for_resolution(path, self.resolution, self.unit, self.fallback_mode)
+            W, H = get_dimensions_for_level(path, selected_level)
+
             self.log.info(f"Starting on Slide {wsi_id}")
             yield Slide(
                 wsi_id=wsi_id,
                 wsi_path=path,
                 dims=(W, H),
-                meta={"slide.wsi_id": wsi_id, "slide.level": self.level, "slide.path": path},
+                level=selected_level,
+                meta={
+                    "slide.wsi_id": wsi_id,
+                    "slide.requested_resolution": self.resolution,
+                    "slide.requested_unit": self.unit,
+                    "slide.requested_fallback_mode": self.fallback_mode,
+                    "slide.selected_level": selected_level,
+                    "slide.path": path,
+                },
             )
 
     def check_slide_exists(self, path: str) -> bool:

--- a/tests/unit/src/wsi_patching/backends/test_cucim_openslide.py
+++ b/tests/unit/src/wsi_patching/backends/test_cucim_openslide.py
@@ -4,7 +4,6 @@ import pytest
 import wsi_patching.backends.cucim_openslide as mod
 
 
-# ---------- fakes ----------
 class FakeCuImage:
     def __init__(self, path):
         self.path = path
@@ -34,19 +33,38 @@ class FakePILImage:
 
 
 class FakeOpenSlide:
-    # OpenSlide exposes .level_dimensions
-    level_dimensions = [(300, 200), (120, 80)]
+    """
+    Fake OpenSlide object.
+
+    It mimics the attributes used by:
+      - get_dimensions_for_level  (level_dimensions, level_count)
+      - get_level_for_resolution (level_downsamples, properties, level_count)
+      - read_region              (for CPU path in read_region)
+    """
 
     def __init__(self, path):
         self.path = path
+        self.level_dimensions = [(300, 200), (120, 80), (60, 40)]
+        self.level_downsamples = [1.0, 2.0, 4.0]
+        self.level_count = len(self.level_dimensions)
+        # mpp at level 0
+        self.properties = {"openslide.mpp-x": "0.5"}
 
     def read_region(self, location, level, size):
-        # location: (x,y), level: int, size: (w,h)
+        # location: (x, y), level: int, size: (w, h)
         w, h = size
         return FakePILImage(w, h, fill=5)
 
     def close(self):
         pass
+
+
+class FakeOpenSlideNoMPP(FakeOpenSlide):
+    """Same as FakeOpenSlide, but without mpp metadata."""
+
+    def __init__(self, path):
+        super().__init__(path)
+        self.properties = {}  # no "openslide.mpp-x"
 
 
 # ---------- tests ----------
@@ -59,29 +77,109 @@ def test_validate_slide_backend_raises_when_gpu_requested_but_cucim_missing(monk
     mod.validate_slide_backend(use_gpu=False)
 
 
-def test_get_dimensions_for_level_cpu(monkeypatch):
-    monkeypatch.setattr(mod, "_cucim_available", False, raising=True)
-    monkeypatch.setattr(mod, "OpenSlide", FakeOpenSlide, raising=True)
+def test_get_dimensions_for_level(monkeypatch):
+    # Force get_dimensions_for_level to use our fake OpenSlide
+    def _ctor(path):
+        assert path == "dummy.svs"
+        return FakeOpenSlide(path)
 
-    W, H = mod.get_dimensions_for_level("dummy.svs", level=1, use_gpu=False)
+    monkeypatch.setattr(mod, "_open_slide_using_openslide", _ctor, raising=True)
+
+    W, H = mod.get_dimensions_for_level("dummy.svs", level=1)
     assert (W, H) == (120, 80)  # from FakeOpenSlide.level_dimensions[1]
     assert isinstance(W, int) and isinstance(H, int)
 
 
-def test_get_dimensions_for_level_gpu_with_cucim(monkeypatch):
-    # Pretend cuCIM is available
-    monkeypatch.setattr(mod, "_cucim_available", True, raising=True)
+def test_get_dimensions_for_level_invalid_level_raises(monkeypatch):
+    def _ctor(path):
+        return FakeOpenSlide(path)
 
-    # CuImage is the constructor, CuImageType is the type used in isinstance(...)
-    monkeypatch.setattr(mod, "CuImage", FakeCuImage, raising=False)
-    monkeypatch.setattr(mod, "CuImageType", FakeCuImage, raising=False)
+    monkeypatch.setattr(mod, "_open_slide_using_openslide", _ctor, raising=True)
 
-    W, H = mod.get_dimensions_for_level("dummy.tif", level=1, use_gpu=True)
-    assert (W, H) == (25, 10)  # from FakeCuImage.resolutions["level_dimensions"][1]
-    assert isinstance(W, int) and isinstance(H, int)
+    # level too high
+    with pytest.raises(AssertionError):
+        mod.get_dimensions_for_level("dummy.svs", level=10)
+
+
+def test_get_level_for_resolution_unit_level(monkeypatch):
+    def _ctor(path):
+        return FakeOpenSlide(path)
+
+    monkeypatch.setattr(mod, "_open_slide_using_openslide", _ctor, raising=True)
+
+    # valid integer level
+    assert mod.get_level_for_resolution(path="dummy.svs", resolution=1, unit="level", fallback_mode="nearest") == 1
+
+    # non-integer resolution should fail for unit="level"
+    with pytest.raises(ValueError):
+        mod.get_level_for_resolution(path="dummy.svs", resolution=1.5, unit="level", fallback_mode="nearest")
+
+    # negative or out-of-range levels should fail
+    with pytest.raises(ValueError):
+        mod.get_level_for_resolution(path="dummy.svs", resolution=-1, unit="level", fallback_mode="nearest")
+
+    with pytest.raises(ValueError):
+        mod.get_level_for_resolution(path="dummy.svs", resolution=99, unit="level", fallback_mode="nearest")
+
+
+def test_get_level_for_resolution_downsample_fallback_modes(monkeypatch):
+    def _ctor(path):
+        return FakeOpenSlide(path)
+
+    monkeypatch.setattr(mod, "_open_slide_using_openslide", _ctor, raising=True)
+
+    # level_downsamples = [1.0, 2.0, 4.0]
+
+    # nearest: requested 1.3 → nearest to 1.0 vs 2.0 vs 4.0 is 1.0 (idx 0)
+    assert (
+        mod.get_level_for_resolution(path="dummy.svs", resolution=1.3, unit="downsample", fallback_mode="nearest") == 0
+    )
+
+    # floor: coarsest with value >= requested
+    # requested 1.1 → eligible 2.0, 4.0 → choose 2.0 (idx 1)
+    assert mod.get_level_for_resolution(path="dummy.svs", resolution=1.1, unit="downsample", fallback_mode="floor") == 1
+
+    # floor: requested too large (e.g. 10) → fallback to coarsest (idx 2)
+    assert (
+        mod.get_level_for_resolution(path="dummy.svs", resolution=10.0, unit="downsample", fallback_mode="floor") == 2
+    )
+
+    # ceil: finest with value <= requested
+    # requested 1.3 → eligible 1.0 → idx 0
+    assert mod.get_level_for_resolution(path="dummy.svs", resolution=1.3, unit="downsample", fallback_mode="ceil") == 0
+    # ceil: requested smaller than all (e.g. 0.1) → fallback to level 0
+    assert mod.get_level_for_resolution(path="dummy.svs", resolution=0.1, unit="downsample", fallback_mode="ceil") == 0
+
+    # error: exact match required
+    assert mod.get_level_for_resolution(path="dummy.svs", resolution=4.0, unit="downsample", fallback_mode="error") == 2
+    with pytest.raises(ValueError):
+        mod.get_level_for_resolution(path="dummy.svs", resolution=3.0, unit="downsample", fallback_mode="error")
+
+
+def test_get_level_for_resolution_mpp_requires_metadata(monkeypatch):
+    def _ctor(path):
+        return FakeOpenSlideNoMPP(path)
+
+    monkeypatch.setattr(mod, "_open_slide_using_openslide", _ctor, raising=True)
+
+    with pytest.raises(ValueError):
+        mod.get_level_for_resolution(path="dummy.svs", resolution=0.5, unit="mpp", fallback_mode="nearest")
+
+
+def test_get_level_for_resolution_mpp_nearest(monkeypatch):
+    def _ctor(path):
+        return FakeOpenSlide(path)
+
+    monkeypatch.setattr(mod, "_open_slide_using_openslide", _ctor, raising=True)
+
+    # FakeOpenSlide: mpp0 = 0.5, level_downsamples [1.0, 2.0, 4.0]
+    # values = [0.5, 1.0, 2.0]
+    # request 0.8 → nearest is 1.0 (idx 1)
+    assert mod.get_level_for_resolution(path="dummy.svs", resolution=0.8, unit="mpp", fallback_mode="nearest") == 1
 
 
 def test_read_region_cpu_returns_numpy_and_uses_openslide(monkeypatch):
+    # Force CPU path via _cucim_available=False and OpenSlide→FakeOpenSlide
     monkeypatch.setattr(mod, "_cucim_available", False, raising=True)
     monkeypatch.setattr(mod, "OpenSlide", FakeOpenSlide, raising=True)
 

--- a/tests/unit/src/wsi_patching/core/test_chunking_and_batching.py
+++ b/tests/unit/src/wsi_patching/core/test_chunking_and_batching.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from wsi_patching.core.chunking_and_batching import ReadWindowChunker, RegionReadAndBatch, TilePlanner
+from wsi_patching.core.chunking_and_batching import PatchExtractor, ReadWindowChunker, RegionReadAndBatch, TilePlanner
 from wsi_patching.core.types.types import RegionTask, Slide, SlideWithROIs, TilePlan
 from wsi_patching.regions_of_interest.rois import BoxROI
 from wsi_patching.utils.meta_typing import PipelineContext
@@ -34,7 +34,7 @@ def test_tileplanner_whole_slide_no_rois_generates_tiles():
 
 def test_tileplanner_center_mode_accepts_boundary_tiles():
     # ROI that starts at (8,8) sized 9x9; tile_size 16
-    # full_inside_bounds would reject (0,0) tile, but center (8,8) lies inside -> accept in center_in_roi.
+    # full_inside_bounds would reject (0,0) tile, but center (16,16) lies inside -> accept in center_in_roi.
     slide = SlideWithROIs("S", "/s", (40, 40), {}, rois=[BoxROI(8, 8, 9, 9)])
     tp = TilePlanner(tile_size=16, stride=16, tile_selection_mode="center_in_roi")
     tp.attach_context(PipelineContext({"tile_size": 16, "stride": 16, "level": 0}))
@@ -153,6 +153,7 @@ def test_readwindowchunker_groups_tiles_into_windows():
         wsi_id="S",
         wsi_path="/s",
         dims=(128, 64),
+        level=0,
         roi_index=0,
         roi_bounds=(0, 0, 64, 32),
         tiles=[
@@ -190,6 +191,7 @@ def test_region_read_and_batch_happy_path_and_batch_split():
             wsi_id="S",
             wsi_path="/s",
             wsi_dims=(64, 64),
+            level=0,
             region=(0, 0, 48, 32),
             tiles=[(0, 0), (16, 0), (32, 0), (0, 16), (16, 16)],
             meta={"m": 1},
@@ -225,6 +227,7 @@ def test_region_read_and_batch_skips_incomplete_patches():
                 wsi_id="S",
                 wsi_path="/s",
                 wsi_dims=(20, 20),
+                level=0,
                 region=(0, 0, 20, 20),
                 tiles=[(0, 0), (8, 8)],  # second will be partial (12x12)
                 meta={},
@@ -254,6 +257,7 @@ def test_region_read_and_batch_pads_incomplete_patches_pad_with_zeros():
                 wsi_id="S",
                 wsi_path="/s",
                 wsi_dims=(20, 20),
+                level=0,
                 region=(0, 0, 20, 20),
                 tiles=[(0, 0), (8, 8)],  # second will be partial (12x12)
                 meta={},
@@ -272,7 +276,7 @@ def test_region_read_and_batch_pads_incomplete_patches_pad_with_zeros():
 
 @patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
 def test_region_read_and_batch_pads_incomplete_patches_pad_with_edge():
-    # region 20x20, tile_size 16 -> tile at (8,8) gives rx=8, ry=8; patch 12x12 -> should be padded to 16x16 with zeros
+    # region 20x20, tile_size 16 -> tile at (8,8) gives rx=8, ry=8; patch 12x12 -> should be padded to 16x16 with edge
     def _fake_read_region(path, x, y, w, h, level, use_gpu, num_workers_cucim):
         return np.full((h, w, 3), 1, dtype=np.uint8)
 
@@ -282,6 +286,7 @@ def test_region_read_and_batch_pads_incomplete_patches_pad_with_edge():
                 wsi_id="S",
                 wsi_path="/s",
                 wsi_dims=(20, 20),
+                level=0,
                 region=(0, 0, 20, 20),
                 tiles=[(0, 0), (8, 8)],  # second will be partial (12x12)
                 meta={},
@@ -310,6 +315,7 @@ def test_region_read_and_batch_pads_incomplete_patches_within_roi_pad_with_zeros
                 wsi_id="S",
                 wsi_path="/s",
                 wsi_dims=(40, 40),
+                level=0,
                 region=(0, 0, 20, 20),
                 tiles=[(0, 0), (8, 8)],  # second will be partial (12x12)
                 meta={},
@@ -330,3 +336,64 @@ def test_region_read_and_batch_pads_incomplete_patches_within_roi_pad_with_zeros
         batch = out[0]  # Get the batch
         assert all(batch.coords[1] == 8)
         assert np.all(batch.patches[1, 12:, :, :] == 0)
+
+
+@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
+def test_region_read_and_batch_roi_edge_policy_read_from_image_expands_region():
+    """
+    When roi_edge_policy='read_from_image', RegionReadAndBatch should expand the
+    region width/height to the next tile_size multiple, but not beyond wsi_dims.
+    """
+    recorded = {}
+
+    def _fake_read_region(path, x, y, w, h, level, use_gpu, num_workers_cucim):
+        recorded["size"] = (w, h)
+        return np.zeros((h, w, 3), dtype=np.uint8)
+
+    with patch("wsi_patching.core.chunking_and_batching.read_region", new=_fake_read_region):
+        # region 20x20 within a 40x40 WSI, tile_size=16 -> should expand to 32x32
+        tasks = [
+            RegionTask(
+                wsi_id="S", wsi_path="/s", wsi_dims=(40, 40), level=0, region=(0, 0, 20, 20), tiles=[(0, 0)], meta={}
+            )
+        ]
+        r = RegionReadAndBatch(
+            batch_size=10, num_workers=1, dtype=np.uint8, roi_edge_policy="read_from_image", wsi_edge_policy="drop"
+        )
+        r.attach_context(PipelineContext({"tile_size": 16, "level": 0, "use_gpu": False}))
+        r.validate()
+
+        list(r(iter(tasks)))
+        assert recorded["size"] == (32, 32)
+
+
+# ------------------- PatchExtractor (composite stage) -------------------
+@patch("wsi_patching.core.chunking_and_batching.get_xp_backend", new=lambda use_gpu: np)
+@patch("wsi_patching.core.chunking_and_batching.read_region", new=fake_read_region)
+def test_patchextractor_end_to_end_whole_slide():
+    """
+    Basic end-to-end test of PatchExtractor using a whole slide with no ROIs.
+
+    64x64 slide, tile_size=16, stride=16 -> 4x4 grid = 16 patches total.
+    """
+    slide = Slide("S", "/s", (64, 64), {})
+
+    pe = PatchExtractor(
+        tile_size=16,
+        stride=16,
+        max_batch_size=5,
+        num_workers=0,
+        wsi_edge_policy="pad_with_zeros",
+        roi_edge_policy="use_wsi_edge_policy",
+        dtype=np.uint8,
+    )
+    ctx = PipelineContext({"tile_size": 16, "stride": 16, "level": 0, "use_gpu": False})
+    pe.attach_context(ctx)
+    pe.validate()
+
+    batches = list(pe(iter([slide])))
+    assert len(batches) > 0
+
+    total_patches = sum(b.patches.shape[0] for b in batches)
+    # Expect full coverage: 4x4 = 16 patches
+    assert total_patches == 16

--- a/tests/unit/src/wsi_patching/core/test_wsi_grid.py
+++ b/tests/unit/src/wsi_patching/core/test_wsi_grid.py
@@ -5,10 +5,13 @@ from wsi_patching.core.wsi_grid import WSIGrid
 
 
 def test_export_context_sets_expected_keys():
-    grid = WSIGrid(slides=["/data/A.svs"], use_gpu=True, level=2)
+    grid = WSIGrid(slides=["/data/A.svs"], use_gpu=True, resolution=0.5, unit="mpp", fallback_mode="nearest")
     ctx = PipelineContext({})
     grid.export_context(ctx)
-    assert ctx["level"] == 2
+
+    assert ctx["resolution"] == 0.5
+    assert ctx["unit"] == "mpp"
+    assert ctx["fallback_mode"] == "nearest"
     assert ctx["use_gpu"] is True
 
 
@@ -16,39 +19,57 @@ def test_export_context_sets_expected_keys():
 @patch("wsi_patching.core.wsi_grid.validate_xp_backend")
 @patch("wsi_patching.core.wsi_grid.validate_slide_backend")
 def test_validate_invokes_backends(mock_validate_slide, mock_validate_xp):
-    grid = WSIGrid(slides=[], use_gpu=False, level=0)
+    grid = WSIGrid(slides=[], use_gpu=False, resolution=0.5, unit="mpp")
     grid.validate()
     mock_validate_slide.assert_called_once_with(False)
     mock_validate_xp.assert_called_once_with(False)
 
     # Also check use_gpu=True path
-    grid2 = WSIGrid(slides=[], use_gpu=True, level=0)
+    grid2 = WSIGrid(slides=[], use_gpu=True, resolution=0.5, unit="mpp")
     grid2.validate()
     assert mock_validate_slide.call_args_list[-1] == call(True)
     assert mock_validate_xp.call_args_list[-1] == call(True)
 
 
 def test_for_slide_returns_single_slide_clone():
-    grid = WSIGrid(slides=["/data/A.svs", "/data/B.svs"], use_gpu=True, level=1)
+    grid = WSIGrid(
+        slides=["/data/A.svs", "/data/B.svs"], use_gpu=True, resolution=0.5, unit="mpp", fallback_mode="nearest"
+    )
+
     g2 = grid.for_slide("/data/C.svs")
     assert isinstance(g2, WSIGrid)
     assert g2.slides == ["/data/C.svs"]
     assert g2.use_gpu is True
-    assert g2.level == 1
+    assert g2.resolution == 0.5
+    assert g2.unit == "mpp"
+    assert g2.fallback_mode == "nearest"
 
 
 @patch("wsi_patching.core.wsi_grid.Path.exists", return_value=True)
 @patch("wsi_patching.core.wsi_grid.get_dimensions_for_level")
-def test_call_yields_slide_objects_with_dims(mock_dims, mock_exists):
-    # Mock per-path dimensions
-    def _dims(path, level, use_gpu):
+@patch("wsi_patching.core.wsi_grid.get_level_for_resolution")
+def test_call_yields_slide_objects_with_dims(mock_get_level, mock_dims, mock_exists):
+    # Mock per-path selected levels
+    def _get_level(path, resolution, unit, fallback_mode):
         if path.endswith("A.svs"):
+            return 1
+        return 2
+
+    mock_get_level.side_effect = _get_level
+
+    # Mock per-path dimensions (note: new signature is (path, level))
+    def _dims(path, level):
+        if path.endswith("A.svs"):
+            assert level == 1
             return (1000, 800)
+        assert level == 2
         return (640, 480)
 
     mock_dims.side_effect = _dims
 
-    grid = WSIGrid(slides=["/slides/A.svs", "/slides/B.svs"], use_gpu=False, level=0)
+    grid = WSIGrid(
+        slides=["/slides/A.svs", "/slides/B.svs"], use_gpu=False, resolution=0.5, unit="mpp", fallback_mode="nearest"
+    )
 
     out = list(grid(iter(())))
     assert len(out) == 2
@@ -58,12 +79,26 @@ def test_call_yields_slide_objects_with_dims(mock_dims, mock_exists):
     assert s0.wsi_id == "A"
     assert s0.wsi_path.endswith("/slides/A.svs")
     assert s0.dims == (1000, 800)
+    assert s0.level == 1
     assert isinstance(s0.meta, dict)
+    assert s0.meta["slide.wsi_id"] == "A"
+    assert s0.meta["slide.requested_resolution"] == 0.5
+    assert s0.meta["slide.requested_unit"] == "mpp"
+    assert s0.meta["slide.requested_fallback_mode"] == "nearest"
+    assert s0.meta["slide.selected_level"] == 1
+    assert s0.meta["slide.path"].endswith("/slides/A.svs")
 
     assert s1.wsi_id == "B"
     assert s1.wsi_path.endswith("/slides/B.svs")
     assert s1.dims == (640, 480)
+    assert s1.level == 2
     assert isinstance(s1.meta, dict)
+    assert s1.meta["slide.selected_level"] == 2
 
-    # get_dimensions_for_level called with our level/use_gpu
-    mock_dims.assert_has_calls([call("/slides/A.svs", 0, False), call("/slides/B.svs", 0, False)])
+    # get_level_for_resolution called with our resolution/unit/fallback_mode
+    mock_get_level.assert_has_calls(
+        [call("/slides/A.svs", 0.5, "mpp", "nearest"), call("/slides/B.svs", 0.5, "mpp", "nearest")]
+    )
+
+    # get_dimensions_for_level called with (path, level)
+    mock_dims.assert_has_calls([call("/slides/A.svs", 1), call("/slides/B.svs", 2)])

--- a/tests/unit/src/wsi_patching/regions_of_interest/test_attach_rois.py
+++ b/tests/unit/src/wsi_patching/regions_of_interest/test_attach_rois.py
@@ -11,12 +11,13 @@ class SlideStub:
     wsi_id: str
     wsi_path: str
     dims: Tuple[int, int]  # (W, H)
+    level: int
     meta: dict
 
 
 def test_attach_rois_combines_providers_and_defaults_with_warning(caplog):
-    slideA = SlideStub("A", "/a", (100, 100), {})
-    slideB = SlideStub("B", "/b", (50, 40), {})
+    slideA = SlideStub("A", "/a", (100, 100), 0, {})
+    slideB = SlideStub("B", "/b", (50, 40), 0, {})
 
     class StaticProv(ROIProvider):
         def for_slide(self, slide):


### PR DESCRIPTION
Previously, one could only choose to extract patches from a selected 'level' (referring to levels in the pyramid structure of the wsis). 

This pull requests extends this functionality. 

WSI grid now has a 3 parameters replacing the previous level parameter
- resolution: Desired resolution for patch extraction.
- unit: Unit of the resolution ("level", "mpp", or "downsample").
- fallback_mode: Strategy for selecting resolution if exact match is unavailable (default is "error"). Options are ("nearest", "floor", "ceil", "error").

Closes #22 