### PR TITLE
Fixed regions of interest error handling

### DIFF
--- a/src/wsi_patching/regions_of_interest/attach_rois.py
+++ b/src/wsi_patching/regions_of_interest/attach_rois.py
@@ -26,19 +26,34 @@ class AttachROIs(Stage):
     def __call__(self, it: Iterable[Slide]) -> Iterable[SlideWithROIs]:
         for s in it:
             all_rois = []
+            provider_errors: List[Exception] = []
+
             for prov in self.providers:
                 try:
                     slide_rois = prov.for_slide(s)
                     all_rois.extend(slide_rois)
                     self.log.info(f"{type(prov).__name__} found {len(slide_rois)} ROIs for slide {s.wsi_id}")
                 except Exception as e:
-                    self.log.info(f"{type(prov).__name__} failed: {e}")
+                    provider_errors.append(e)
+                    self.log.error(f"{type(prov).__name__} failed: {e}")
 
             if not all_rois:
                 if self.on_empty == "error":
-                    raise ValueError(f"No ROIs found for slide {s.wsi_id}")
+                    # If all providers failed, raise the real underlying exception(s)
+                    if len(provider_errors) == 1:
+                        raise provider_errors[0]
+                    if len(provider_errors) > 1:
+                        msg = (
+                            f"No valid ROIs found for slide {s.wsi_id}; "
+                            f"{len(provider_errors)} provider(s) failed: "
+                            + "; ".join(f"{type(e).__name__}: {e}" for e in provider_errors)
+                        )
+                        raise ValueError(msg) from provider_errors[0]
+
+                    # No providers failed, they just returned empty
+                    raise ValueError(f"No valid ROIs found for slide {s.wsi_id}")
 
                 all_rois = WholeSlideProvider().for_slide(s)
-                self.log.warning(f"No ROIs found for slide {s.wsi_id}; using whole slide.")
+                self.log.warning(f"No valid ROIs found for slide {s.wsi_id}; using whole slide.")
 
             yield SlideWithROIs(**s.__dict__, rois=all_rois)

--- a/src/wsi_patching/regions_of_interest/roi_providers.py
+++ b/src/wsi_patching/regions_of_interest/roi_providers.py
@@ -36,6 +36,7 @@ class RectROIfromXMLProvider(ROIProvider):
         xml_file = self.rois[slide.wsi_id]
         tree = ET.parse(xml_file)
         root = tree.getroot()
+        W, H = slide.dims
 
         for ann in root.findall(".//Annotation[@PartOfGroup='roi']"):
             if ann.get("Type") != "Rectangle":
@@ -50,6 +51,10 @@ class RectROIfromXMLProvider(ROIProvider):
 
             x_min, y_min = min(xs), min(ys)
             x_max, y_max = max(xs), max(ys)
+            if x_min < 0 or y_min < 0 or x_max > W or y_max > H:
+                raise ValueError(
+                    f"ROI {(x_min, y_min, x_max - x_min, y_max - y_min)} for slide {slide.wsi_id} lies outside {(W, H)}"
+                )
             out.append(BoxROI(int(x_min), int(y_min), int(x_max - x_min), int(y_max - y_min)))
 
         return out

--- a/tests/unit/src/wsi_patching/regions_of_interest/test_attach_rois.py
+++ b/tests/unit/src/wsi_patching/regions_of_interest/test_attach_rois.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+import pytest
+
 from wsi_patching.regions_of_interest.attach_rois import AttachROIs
-from wsi_patching.regions_of_interest.roi_providers import ROIProvider
+from wsi_patching.regions_of_interest.roi_providers import RectROIProvider, ROIProvider
 from wsi_patching.regions_of_interest.rois import BoxROI
 
 
@@ -48,4 +50,47 @@ def test_attach_rois_combines_providers_and_defaults_with_warning(caplog):
     assert b.rois[0].bounds() == (0, 0, 50, 40)
     # log messages: provider failure + fallback warning
     assert "failed:" in caplog.text
-    assert "No ROIs found for slide B; using whole slide." in caplog.text
+    assert "No valid ROIs found for slide B; using whole slide." in caplog.text
+
+
+def test_attach_rois_out_of_bounds_roi_raises_actual_provider_exception(caplog):
+    slide = SlideStub("A", "/a", (100, 100), 0, {})
+
+    prov = RectROIProvider(rois={"A": [(90, 90, 20, 20)]})  # out of bounds
+    attach = AttachROIs([prov], on_empty="error")
+
+    caplog.set_level("INFO")
+
+    # Now we expect the original provider error, not "No valid ROIs found..."
+    with pytest.raises(ValueError, match=r"lies outside"):
+        list(attach(iter([slide])))
+
+    assert "RectROIProvider failed:" in caplog.text
+    assert "lies outside" in caplog.text
+
+
+def test_attach_rois_multiple_provider_failures_aggregates_and_sets_cause(caplog):
+    slide = SlideStub("A", "/a", (100, 100), 0, {})
+
+    class BoomProv(ROIProvider):
+        def for_slide(self, slide):
+            raise RuntimeError("bang")
+
+    oob = RectROIProvider(rois={"A": [(90, 90, 20, 20)]})
+    attach = AttachROIs([BoomProv(), oob], on_empty="error")
+
+    caplog.set_level("INFO")
+
+    with pytest.raises(ValueError) as excinfo:
+        list(attach(iter([slide])))
+
+    # Aggregated message contains both failures
+    msg = str(excinfo.value)
+    assert "No valid ROIs found for slide A" in msg
+    assert "RuntimeError: bang" in msg
+    assert "ValueError:" in msg and "lies outside" in msg
+
+    # Cause should be set (from provider_errors[0])
+    assert excinfo.value.__cause__ is not None
+
+    assert "failed:" in caplog.text


### PR DESCRIPTION
- attach_rois now raises the last error in the roi provider
- both standard box roi providers now also provide errors when roi is outside the image itself.

Closes #46 